### PR TITLE
fix: Remove stop tokens from LLM output

### DIFF
--- a/voice_assistant/model.py
+++ b/voice_assistant/model.py
@@ -78,14 +78,22 @@ class LLM:
                 f"<|assistant|>\n"
             )
 
-        response = self.llm(text_prompt, 
-                            temperature=self.temperature, 
-                            top_p=self.top_p, 
-                            repeat_penalty=self.repeat_penalty, 
+        response = self.llm(text_prompt,
+                            temperature=self.temperature,
+                            top_p=self.top_p,
+                            repeat_penalty=self.repeat_penalty,
                             max_tokens=self.max_tokens,
                             stop=self.stop,
                             echo=self.echo)
-        return response["choices"][0]["text"].strip()
+
+        # Extract and clean the response text
+        response_text = response["choices"][0]["text"].strip()
+
+        # Remove any stop tokens that might have leaked through
+        for stop_token in self.stop:
+            response_text = response_text.replace(stop_token, "")
+
+        return response_text.strip()
     
     def add_to_memory(self, user_message: str, assistant_response: str):
         """Add conversation to memory"""


### PR DESCRIPTION
Fixed issue where stop tokens (specifically <|end|>) were appearing
in the generated responses. Now explicitly filtering out all stop
tokens ("Q:", "\n", "<|end|>") from the response text before
returning it to the user.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures clean assistant outputs by removing stop tokens that could appear in the generated text.
> 
> - Post-process `LLM.generate` to strip `"Q:"`, `"\n"`, and `"<|end|>"` from `response["choices"][0]["text"]` before returning
> - Minor formatting adjustments to the `self.llm(...)` call arguments
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e44c01a3d8ba01287625c2399f662c46639b026. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->