### PR TITLE
feat: Replace llama-cpp-python with Ollama for Mistral 7B Q4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "fastrtc>=0.0.26",
     "fastrtc[vad]",
     "fastrtc[stopword]",
-    "llama-cpp-python",
+    "ollama",
     "torch==2.7.1+cpu",
     "soxr",
     "kokoro_onnx",
@@ -78,10 +78,17 @@ uv sync
 
 download-llm = """
 bash -c '
-mkdir -p voice_assistant/models
-cd voice_assistant/models 
-wget -nc https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/resolve/main/mistral-7b-instruct-v0.1.Q4_K_M.gguf
-cd ../..
+echo "🔧 Pulling Mistral 7B model with Ollama (Q4 quantization)..."
+if ! command -v ollama &> /dev/null; then
+    echo "❌ Ollama not found. Please install Ollama first:"
+    echo "   curl -fsSL https://ollama.com/install.sh | sh"
+    exit 1
+fi
+
+# Pull Mistral 7B with Q4 quantization
+ollama pull mistral:7b-instruct-q4_K_M
+
+echo "✅ Mistral 7B model ready!"
 '
 """
 
@@ -96,7 +103,16 @@ start = [
 smart-run = """
 python -c '
 import os
-if not os.path.exists(".venv") or not os.path.exists("voice_assistant/models/mistral-7b-instruct-v0.1.Q4_K_M.gguf"):
+import subprocess
+
+# Check if Ollama model is available
+try:
+    result = subprocess.run(["ollama", "list"], capture_output=True, text=True, check=False)
+    has_model = "mistral" in result.stdout
+except FileNotFoundError:
+    has_model = False
+
+if not os.path.exists(".venv") or not has_model:
     print("🔧 First-time setup...")
     os.system("poe start")
 else:

--- a/tests/interactive_llm_test.py
+++ b/tests/interactive_llm_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Interactive test script for the LLM model.
-This script allows you to chat directly with the Mistral-7B model.
+This script allows you to chat directly with the Mistral-7B model via Ollama.
 """
 
 import os
@@ -18,25 +18,19 @@ import hydra
 
 def load_llm():
     """Load the LLM model."""
-    print("🔧 Loading LLM model...")
-    
-    # Get the model path from the project structure
-    # Load configuration
-    with hydra.initialize_config_dir(version_base=None, config_dir="voice_assistant/cli/conf"):
-        cfg = hydra.compose(config_name="base")
-        model_path = Path(cfg.model.path)
-    if not model_path.exists():
-        print(f"❌ Model not found at: {model_path}")
-        print("Please run 'poe download-llm' first to download the model.")
-        return None
-    
+    print("🔧 Loading LLM model with Ollama...")
+
     try:
-        # Initialize the LLM with the same parameters as in the main app
-        llm = LLM(str(model_path), n_ctx=512)
-        print("✅ LLM loaded successfully!")
+        # Initialize the LLM with Ollama
+        llm = LLM(model_name="mistral:7b-instruct-q4_K_M")
+        print("✅ LLM loaded successfully with Ollama!")
         return llm
     except Exception as e:
         print(f"❌ Error loading LLM: {e}")
+        print("Please ensure:")
+        print("1. Ollama is installed (curl -fsSL https://ollama.com/install.sh | sh)")
+        print("2. Ollama service is running (ollama serve)")
+        print("3. Model is downloaded (poe download-llm or ollama pull mistral:7b-instruct-q4_K_M)")
         return None
 
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -18,23 +18,19 @@ from util import timer
 
 def test_llm_loading():
     """Test that the LLM can be loaded successfully."""
-    print("🔧 Testing LLM loading...")
-    
-    # Get the model path from the project structure
-    model_path = Path(__file__).parent.parent / "voice_assistant" / "models" / "mistral-7b-instruct-v0.1.Q4_K_M.gguf"
-    
-    if not model_path.exists():
-        print(f"❌ Model not found at: {model_path}")
-        print("Please run 'poe download-llm' first to download the model.")
-        return False
-    
+    print("🔧 Testing LLM loading with Ollama...")
+
     try:
-        # Initialize the LLM with the same parameters as in the main app
-        llm = LLM(str(model_path), n_ctx=512)
-        print("✅ LLM loaded successfully!")
+        # Initialize the LLM with Ollama (model should be pulled via 'poe download-llm')
+        llm = LLM(model_name="mistral:7b-instruct-q4_K_M")
+        print("✅ LLM loaded successfully with Ollama!")
         return llm
     except Exception as e:
         print(f"❌ Error loading LLM: {e}")
+        print("Please ensure:")
+        print("1. Ollama is installed (curl -fsSL https://ollama.com/install.sh | sh)")
+        print("2. Ollama service is running (ollama serve)")
+        print("3. Model is downloaded (poe download-llm)")
         return False
 
 
@@ -180,9 +176,10 @@ def main():
     print("\n" + "=" * 50)
     print("✅ LLM Test Suite completed!")
     print("\n💡 Tips:")
-    print("- If responses are slow, consider using a smaller model")
+    print("- If responses are slow, consider using a smaller model or different quantization")
     print("- If responses are poor quality, try adjusting temperature or other parameters")
-    print("- The model uses llama-cpp-python for inference")
+    print("- The model uses Ollama for inference with Mistral 7B Q4 quantization")
+    print("- To check available models: ollama list")
 
 
 if __name__ == "__main__":

--- a/voice_assistant/cli/conf/base.yaml
+++ b/voice_assistant/cli/conf/base.yaml
@@ -11,15 +11,13 @@ tts:
 
 llm:
   _target_: voice_assistant.model.LLM
-  model_path: "models/mistral-7b-instruct-v0.1.Q4_K_M.gguf"
-  n_ctx: 2048
+  model_name: "mistral:7b-instruct-q4_K_M"
   max_conversations: 10
   memory_file: "data/conversation_memory.json"
   temperature: 0.2
   top_p: 0.9
   repeat_penalty: 1.2
   max_tokens: 25
-  echo: false
 
 stream:
   wake_word: "computer"

--- a/voice_assistant/model.py
+++ b/voice_assistant/model.py
@@ -5,7 +5,7 @@ import hydra
 
 from fastrtc import get_stt_model, get_tts_model, KokoroTTSOptions, AdditionalOutputs
 from fastrtc_whisper_cpp import get_stt_model as get_stt_model_whisper_cpp
-from llama_cpp import Llama
+import ollama
 
 from voice_assistant.util import timer
 from voice_assistant.features.weather import WeatherForecast
@@ -35,60 +35,61 @@ class TTS:
         return self.tts_model.tts(text, options=self.options)
 
 class LLM:
-    def __init__(self, model_path: str, 
-                        n_ctx: int, 
-                        max_conversations: int = 10, 
-                        memory_file: str = "./data/conversation_memory.json", 
-                        temperature: float = 0.2, 
-                        top_p: float = 0.9, 
-                        repeat_penalty: float = 1.2, 
-                        max_tokens: int = 50, 
-                        echo: bool = False):
-        project_root = Path(__file__).parents[0]  # Go up to project root
-        model_path = str((project_root / model_path).resolve())
-        
-        self.llm = Llama(model_path=model_path, 
-                         n_ctx=n_ctx,
-                         n_threads=16,
-                         n_batch=16,
-                         n_gpu_layers=0)
+    def __init__(self, model_name: str = "mistral:7b-instruct-q4_K_M",
+                        max_conversations: int = 10,
+                        memory_file: str = "./data/conversation_memory.json",
+                        temperature: float = 0.2,
+                        top_p: float = 0.9,
+                        repeat_penalty: float = 1.2,
+                        max_tokens: int = 50):
+        self.model_name = model_name
+        self.client = ollama.Client()
         self.memory = ConversationMemory(max_conversations=max_conversations, save_file=memory_file)
         self.temperature = temperature
         self.top_p = top_p
         self.repeat_penalty = repeat_penalty
         self.max_tokens = max_tokens
         self.stop = ["Q:", "\n", "<|end|>"]
-        self.echo = echo
         
     @timer
     def generate(self, prompt: str):
         # Get conversation history context
         context = self.memory.get_context()
-        
-        # Build the complete prompt with memory context
-        if context:
-            text_prompt = (
-                f"<|system|>\nYou are a helpful assistant. Here is the conversation history:\n{context}\n<|end|>\n"
-                f"<|user|>\n{prompt}\n<|end|>\n"
-                f"<|assistant|>\n"
-            )
-        else:
-            text_prompt = (
-                f"<|system|>\nYou are a helpful assistant.<|end|>\n"
-                f"<|user|>\n{prompt}\n<|end|>\n"
-                f"<|assistant|>\n"
-            )
 
-        response = self.llm(text_prompt,
-                            temperature=self.temperature,
-                            top_p=self.top_p,
-                            repeat_penalty=self.repeat_penalty,
-                            max_tokens=self.max_tokens,
-                            stop=self.stop,
-                            echo=self.echo)
+        # Build messages for Ollama chat API
+        messages = []
+
+        if context:
+            messages.append({
+                "role": "system",
+                "content": f"You are a helpful assistant. Here is the conversation history:\n{context}"
+            })
+        else:
+            messages.append({
+                "role": "system",
+                "content": "You are a helpful assistant."
+            })
+
+        messages.append({
+            "role": "user",
+            "content": prompt
+        })
+
+        # Call Ollama API
+        response = self.client.chat(
+            model=self.model_name,
+            messages=messages,
+            options={
+                "temperature": self.temperature,
+                "top_p": self.top_p,
+                "repeat_penalty": self.repeat_penalty,
+                "num_predict": self.max_tokens,
+                "stop": self.stop,
+            }
+        )
 
         # Extract and clean the response text
-        response_text = response["choices"][0]["text"].strip()
+        response_text = response["message"]["content"].strip()
 
         # Remove any stop tokens that might have leaked through
         for stop_token in self.stop:


### PR DESCRIPTION
Replace the local GGUF model loading with Ollama for easier model management
and better performance. This change uses Mistral 7B Instruct with Q4_K_M quantization
via Ollama instead of the previous llama-cpp-python setup.

Changes:
- Replace llama-cpp-python dependency with ollama in pyproject.toml
- Update LLM class to use Ollama client API instead of local GGUF loading
- Modify download-llm script to pull model via Ollama
- Update smart-run to check for Ollama models instead of local GGUF file
- Update base.yaml config to use model_name instead of model_path
- Update test files to work with Ollama setup

Benefits:
- Easier model management (no manual GGUF downloads)
- Better performance with Ollama's optimized inference
- Simpler setup process
- Consistent API across different models